### PR TITLE
Add option to enable/disable infinite slideshow

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Options for slideshow :
 - Transition : which transition animation to use
 - Transition duration : how long the transition will take (in milliseconds). Can't be `0`.
 - Pause on hover : when enabled, if the mouse is over an image, the slideshow will pause.
+- Infinite : when enabled, slideshow continues from start when finished
 
 ## Image tooltip options
 

--- a/src/DynamicImagePanel.tsx
+++ b/src/DynamicImagePanel.tsx
@@ -419,6 +419,7 @@ export function DynamicImagePanel(props: Props) {
       duration: options.slideshow.duration,
       transitionDuration: options.slideshow.transition_duration,
       pauseOnHover: options.slideshow.pauseOnHover,
+      infinite: options.slideshow.infinite,
     };
     return (
       <ConditionalWrapper

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -165,6 +165,14 @@ export const plugin = new PanelPlugin<DynamicImageOptions>(DynamicImagePanel).se
       category: ['Slideshow'],
     })
     .addBooleanSwitch({
+      path: 'slideshow.infinite',
+      name: 'Infinite',
+      description: 'Contnue from start when slideshow finishes',
+      defaultValue: true,
+      showIf: (currentConfig) => currentConfig.slideshow.enable,
+      category: ['Slideshow'],
+    })
+    .addBooleanSwitch({
       path: 'singleFill',
       name: 'Single fill',
       description: 'If there is a single image or slideshow is enabled, it will try to fill panel',

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,7 @@ export interface Slideshow {
   transition_duration: number;
   pauseOnHover: boolean;
   transition: Transition;
+  infinite: boolean;
 }
 
 export interface SharedCrossSupport {


### PR DESCRIPTION
Adds the `infinite` property as an option in slideshow configuration, enabled by default.