### PR TITLE
Fix license link

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -24,7 +24,7 @@
       },
       {
         "name": "MIT",
-        "url": "https://github.com/Dalvany/dalvany-image-panel/blob/master/LICENSE.md"
+        "url": "https://github.com/Dalvany/dalvany-image-panel/blob/main/LICENSE.md"
       }
     ],
     "screenshots": [


### PR DESCRIPTION
Master branch was rename main. Fix the license link accordingly.